### PR TITLE
Remove attributes which don't apply to libraries

### DIFF
--- a/rxfile/src/main/AndroidManifest.xml
+++ b/rxfile/src/main/AndroidManifest.xml
@@ -3,11 +3,6 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
Removes applying app settings for any apps which depend on the library:
 - support RTL
 - allow backup
 - app name

Having some of these tags can have bad side affects as experienced. For example, if app doesn't support RTL expicitly in the AndroidManifest.xml, the build fails as there are conflicting settings.

Fixes #9